### PR TITLE
#1 Added support for git submodules

### DIFF
--- a/src/gitserverlite
+++ b/src/gitserverlite
@@ -48,7 +48,8 @@ shopt -s nullglob
 command="$1"
 argument1="$2"
 
-GSL_DIR=".gitserverlite"
+current_dir=$(pwd)
+GSL_DIR=""$current_dir"/.gitserverlite"
 
 . "$GSL_DIR/env"
 . "$GSL_DIR/gsl-source"

--- a/src/gsl-source
+++ b/src/gsl-source
@@ -88,9 +88,15 @@ process() {
     then
         exit 1
     fi
+
+    if [[ "$deploy_dir" == /* ]];
+    then
+        target="$deploy_dir/deploy_$branch"
+    else
+        target="$git_dir/$deploy_dir/deploy_$branch"
+    fi
     
-    target="$deploy_dir/deploy_$branch"
-    run_command="checkout "$git_dir" "$branch" "$target"; deploy "$target" \""$params"\" "$env_file""
+    run_command="checkout "$git_dir" "$branch" "$target"; deploy "$target" \""$params"\" "$env_file"; clean "$target""
     _run "$run_command"
 }
 
@@ -113,6 +119,18 @@ deploy() {
         run_command="cd "$target"; docker compose --env-file "$env_file" up $params"
     fi
     
+    _run "$run_command"
+}
+
+clean() {
+    target="$1"
+
+    if [[ -z "$target" || "$target" == "/" ]];
+    then
+        exit 1
+    fi
+
+    run_command="rm -rf "$target""
     _run "$run_command"
 }
 
@@ -167,7 +185,7 @@ checkout() {
         exit 1
     fi
     
-    run_command="mkdir -p "$target"; git --work-tree="$target" --git-dir="$git_dir" checkout -f "$branch""
+    run_command="mkdir -p "$target"; git --work-tree="$target" --git-dir="$git_dir" checkout -f "$branch"; git --git-dir="$git_dir" --work-tree=. -C "$target" submodule update --init --recursive --force"
     _run "$run_command"
 }
 

--- a/src/post-receive
+++ b/src/post-receive
@@ -31,17 +31,19 @@
 #for debugging
 #set -ex
 
+git_dir=$(pwd)
+
 while read oldrev newrev ref
 do
-    if [[ -f "$GIT_DIR/hooks/pre-deploy" ]];
+    if [[ -f "$git_dir/hooks/pre-deploy" ]];
     then
-        "$GIT_DIR/hooks/pre-deploy"
+        "$git_dir/hooks/pre-deploy"
     fi
 
-    "$GIT_DIR/.gitserverlite/matchanddeploy" "$ref" "$GIT_DIR"
+    "$git_dir/.gitserverlite/matchanddeploy" "$ref" "$git_dir"
 
-    if [[ -f "$GIT_DIR/hooks/post-deploy" ]];
+    if [[ -f "$git_dir/hooks/post-deploy" ]];
     then
-        "$GIT_DIR/hooks/post-deploy"
+        "$git_dir/hooks/post-deploy"
     fi
 done

--- a/tests/checkout_test.sh
+++ b/tests/checkout_test.sh
@@ -68,7 +68,7 @@ test_checkout_NoTarget_ExpectedExitStatus() {
 
 test_checkout_ValidParametersSingleWorkdBranch_ReturnsExpected() {
     checkout /var/git/my_repo.git main /var/deploy/deploy_main
-    assertEquals "mkdir -p /var/deploy/deploy_main; git --work-tree=/var/deploy/deploy_main --git-dir=/var/git/my_repo.git checkout -f main" "$GSL_LAST_RUN"
+    assertEquals "mkdir -p /var/deploy/deploy_main; git --work-tree=/var/deploy/deploy_main --git-dir=/var/git/my_repo.git checkout -f main; git --git-dir=/var/git/my_repo.git --work-tree=. -C /var/deploy/deploy_main submodule update --init --recursive --force" "$GSL_LAST_RUN"
 }
 
 # Load shUnit2.

--- a/tests/process_test.sh
+++ b/tests/process_test.sh
@@ -73,12 +73,17 @@ test_process_NoBranch_ExpectedExitStatus() {
 
 test_process_NoEnvFile_ReturnsExpected() {
     process /var/git/my_repo.git /var/deploy "--build --deploy" main
-    assertEquals "checkout /var/git/my_repo.git main /var/deploy/deploy_main; deploy /var/deploy/deploy_main \"--build --deploy\" " "$GSL_LAST_RUN"
+    assertEquals "checkout /var/git/my_repo.git main /var/deploy/deploy_main; deploy /var/deploy/deploy_main \"--build --deploy\" ; clean /var/deploy/deploy_main" "$GSL_LAST_RUN"
+}
+
+test_process_RelativeDeployDir_ReturnsExpected() {
+    process /var/git/my_repo.git deploy "--build --deploy" main
+    assertEquals "checkout /var/git/my_repo.git main /var/git/my_repo.git/deploy/deploy_main; deploy /var/git/my_repo.git/deploy/deploy_main \"--build --deploy\" ; clean /var/git/my_repo.git/deploy/deploy_main" "$GSL_LAST_RUN"
 }
 
 test_process_ValidEnvFile_ReturnsExpected() {
     process /var/git/my_repo.git /var/deploy "--build --deploy" main .env.dev
-    assertEquals "checkout /var/git/my_repo.git main /var/deploy/deploy_main; deploy /var/deploy/deploy_main \"--build --deploy\" .env.dev" "$GSL_LAST_RUN"
+    assertEquals "checkout /var/git/my_repo.git main /var/deploy/deploy_main; deploy /var/deploy/deploy_main \"--build --deploy\" .env.dev; clean /var/deploy/deploy_main" "$GSL_LAST_RUN"
 }
 
 # Load shUnit2.


### PR DESCRIPTION
#1 Support for Git submodules

### Notes

When checking out a branch to the deploy folder before runner docker up, no allowance had been made for repositories using git submodules. This PR adds a step in the checkout to initialize and update git submodules.

As part of the cleanup, some paths were changed from relative to absolute. This PR also adds a cleanup step to delete the deployed products after deployment.